### PR TITLE
Add Box utility functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(laser_scan_filters
   src/median_filter.cpp
   src/array_filter.cpp
   src/box_filter.cpp
+  src/box_utils.cpp
   src/polygon_filter.cpp
   src/polygon_utils.cpp
   src/speckle_filter.cpp

--- a/src/box.h
+++ b/src/box.h
@@ -1,3 +1,40 @@
+/*
+ *  Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, SmileRobotics, Japan
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   1. Redistributions of source code must retain the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *   3. Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ *  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #ifndef BOX_H
 #define BOX_H
 

--- a/src/box_utils.cpp
+++ b/src/box_utils.cpp
@@ -106,8 +106,7 @@ Box makeBoxFromXMLRPC(const XmlRpc::XmlRpcValue& box_xmlrpc, const std::string& 
     points[i].z = getNumberFromXMLRPC(point_xmlrpc[2], full_param_name);
   }
 
-  Box box = makeBoxFromTwoPoints(points[0], points[1]);
-  return box;
+  return makeBoxFromTwoPoints(points[0], points[1]);
 }
 
 Box makeBoxFromString(const std::string& box_string, const Box& last_box)
@@ -147,8 +146,7 @@ Box makeBoxFromString(const std::string& box_string, const Box& last_box)
     }
   }
 
-  Box box = makeBoxFromTwoPoints(points[0], points[1]);
-  return box;
+  return makeBoxFromTwoPoints(points[0], points[1]);
 }
 
 Box padBox(const Box& box, double padding)

--- a/src/box_utils.cpp
+++ b/src/box_utils.cpp
@@ -1,0 +1,138 @@
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <geometry_msgs/Point32.h>
+#include <ros/ros.h>
+
+#include "box_utils.h"
+
+std::string boxToString(const Box& box)
+{
+  std::string box_string = "[";
+
+  box_string +=
+      "[" + std::to_string(box.min.x) + ", " + std::to_string(box.min.y) + ", " + std::to_string(box.min.z) + "]";
+
+  box_string += ", ";
+
+  box_string +=
+      "[" + std::to_string(box.max.x) + ", " + std::to_string(box.max.y) + ", " + std::to_string(box.max.z) + "]";
+
+  box_string += "]";
+  return box_string;
+}
+
+Box makeBoxFromTwoPoints(const std::vector<geometry_msgs::Point32>& points)
+{
+  Box box;
+  if (points.size() == 2)
+  {
+    box.min.x = std::min(points[0].x, points[1].x);
+    box.min.y = std::min(points[0].y, points[1].y);
+    box.min.z = std::min(points[0].z, points[1].z);
+
+    box.max.x = std::max(points[0].x, points[1].x);
+    box.max.y = std::max(points[0].y, points[1].y);
+    box.max.z = std::max(points[0].z, points[1].z);
+  }
+
+  return box;
+}
+
+Box makeBoxFromXMLRPC(const XmlRpc::XmlRpcValue& box_xmlrpc, const std::string& full_param_name)
+{
+  // checks if an array has just two elements.
+  if (box_xmlrpc.getType() != XmlRpc::XmlRpcValue::TypeArray || box_xmlrpc.size() != 2)
+  {
+    ROS_FATAL("The box (parameter %s) must be specified as nested list on the parameter server with two points"
+              "i.e. [[x1, y1, z1], [x2, y2, z2]]",
+              full_param_name.c_str());
+
+    throw std::runtime_error("The box must be specified as nested list on the parameter server with two points"
+                             "i.e. [[x1, y1, z1], [x2, y2, z2]]");
+  }
+
+  std::vector<geometry_msgs::Point32> points;
+  points.resize(box_xmlrpc.size());  // points.size() == 2
+
+  for (int i = 0; i < box_xmlrpc.size(); ++i)
+  {
+    // checks if each element (point) has three elements,
+    // i.e. x, y, and z coordinates
+    XmlRpc::XmlRpcValue point_xmlrpc = box_xmlrpc[i];
+    if (point_xmlrpc.getType() != XmlRpc::XmlRpcValue::TypeArray || point_xmlrpc.size() != 3)
+    {
+      ROS_FATAL("The box (parameter %s) must be specified as list of lists,"
+                "i.e. [[x1, y1, z1], [x2, y2, z2]], but this spec is not of that form.",
+                full_param_name.c_str());
+      throw std::runtime_error("The box must be specified as list of lists,"
+                               "i.e. [[x1, y1, z1], [x2, y2, z2]], but this spec is not of that form");
+    }
+
+    points[i].x = getNumberFromXMLRPC(point_xmlrpc[0], full_param_name);
+    points[i].y = getNumberFromXMLRPC(point_xmlrpc[1], full_param_name);
+    points[i].z = getNumberFromXMLRPC(point_xmlrpc[2], full_param_name);
+  }
+
+  Box box = makeBoxFromTwoPoints(points);
+  return box;
+}
+
+Box makeBoxFromString(const std::string& box_string, const Box& last_box)
+{
+  std::string error;
+  std::vector<std::vector<float>> vvf = parseVVF(box_string, error);
+
+  if (error != "")
+  {
+    ROS_ERROR("Error parsing box parameter: '%s'", error.c_str());
+    ROS_ERROR(" Box string was '%s'.", box_string.c_str());
+    return last_box;
+  }
+
+  // convert vvf into points.
+  if (vvf.size() != 2)
+  {
+    ROS_WARN("You must specify just two points to define a box");
+    return last_box;
+  }
+
+  std::vector<geometry_msgs::Point32> points;
+  points.resize(vvf.size());  // points.size() == 2
+
+  for (unsigned int i = 0; i < vvf.size(); i++)
+  {
+    if (vvf[i].size() == 3)
+    {
+      points[i].x = vvf[i][0];
+      points[i].y = vvf[i][1];
+      points[i].z = vvf[i][2];
+    }
+    else
+    {
+      ROS_ERROR("The box must be specified as list of lists,"
+                "i.e. [[x1, y1, z1], [x2, y2, z2]], but this spec is not of that form");
+      return last_box;
+    }
+  }
+
+  Box box = makeBoxFromTwoPoints(points);
+  return box;
+}
+
+Box padBox(const Box& box, double padding)
+{
+  Box box_padded = box;
+
+  // pads the box
+  box_padded.min.x -= padding;
+  box_padded.min.y -= padding;
+  box_padded.min.z -= padding;
+
+  box_padded.max.x += padding;
+  box_padded.max.y += padding;
+  box_padded.max.z += padding;
+
+  return box_padded;
+}

--- a/src/box_utils.cpp
+++ b/src/box_utils.cpp
@@ -36,6 +36,7 @@
  */
 
 #include <algorithm>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -46,18 +47,14 @@
 
 std::string boxToString(const Box& box)
 {
-  std::string box_string = "[";
+  std::stringstream box_stringstream;
+  box_stringstream << "["
+                   << "[" << box.min.x << ", " << box.min.y << ", " << box.min.z << "]"
+                   << ", "
+                   << "[" << box.max.x << ", " << box.max.y << ", " << box.max.z << "]"
+                   << "]";
 
-  box_string +=
-      "[" + std::to_string(box.min.x) + ", " + std::to_string(box.min.y) + ", " + std::to_string(box.min.z) + "]";
-
-  box_string += ", ";
-
-  box_string +=
-      "[" + std::to_string(box.max.x) + ", " + std::to_string(box.max.y) + ", " + std::to_string(box.max.z) + "]";
-
-  box_string += "]";
-  return box_string;
+  return box_stringstream.str();
 }
 
 Box makeBoxFromTwoPoints(const geometry_msgs::Point32& point0, const geometry_msgs::Point32& point1)

--- a/src/box_utils.cpp
+++ b/src/box_utils.cpp
@@ -60,19 +60,17 @@ std::string boxToString(const Box& box)
   return box_string;
 }
 
-Box makeBoxFromTwoPoints(const std::vector<geometry_msgs::Point32>& points)
+Box makeBoxFromTwoPoints(const geometry_msgs::Point32& point0, const geometry_msgs::Point32& point1)
 {
   Box box;
-  if (points.size() == 2)
-  {
-    box.min.x = std::min(points[0].x, points[1].x);
-    box.min.y = std::min(points[0].y, points[1].y);
-    box.min.z = std::min(points[0].z, points[1].z);
 
-    box.max.x = std::max(points[0].x, points[1].x);
-    box.max.y = std::max(points[0].y, points[1].y);
-    box.max.z = std::max(points[0].z, points[1].z);
-  }
+  box.min.x = std::min(point0.x, point1.x);
+  box.min.y = std::min(point0.y, point1.y);
+  box.min.z = std::min(point0.z, point1.z);
+
+  box.max.x = std::max(point0.x, point1.x);
+  box.max.y = std::max(point0.y, point1.y);
+  box.max.z = std::max(point0.z, point1.z);
 
   return box;
 }
@@ -112,7 +110,7 @@ Box makeBoxFromXMLRPC(const XmlRpc::XmlRpcValue& box_xmlrpc, const std::string& 
     points[i].z = getNumberFromXMLRPC(point_xmlrpc[2], full_param_name);
   }
 
-  Box box = makeBoxFromTwoPoints(points);
+  Box box = makeBoxFromTwoPoints(points[0], points[1]);
   return box;
 }
 
@@ -154,7 +152,7 @@ Box makeBoxFromString(const std::string& box_string, const Box& last_box)
     }
   }
 
-  Box box = makeBoxFromTwoPoints(points);
+  Box box = makeBoxFromTwoPoints(points[0], points[1]);
   return box;
 }
 

--- a/src/box_utils.cpp
+++ b/src/box_utils.cpp
@@ -1,3 +1,40 @@
+/*
+ *  Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, SmileRobotics, Japan
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   1. Redistributions of source code must retain the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *   3. Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ *  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include <algorithm>
 #include <string>
 #include <vector>

--- a/src/box_utils.cpp
+++ b/src/box_utils.cpp
@@ -85,8 +85,7 @@ Box makeBoxFromXMLRPC(const XmlRpc::XmlRpcValue& box_xmlrpc, const std::string& 
                              "i.e. [[x1, y1, z1], [x2, y2, z2]]");
   }
 
-  std::vector<geometry_msgs::Point32> points;
-  points.resize(box_xmlrpc.size());  // points.size() == 2
+  std::vector<geometry_msgs::Point32> points(box_xmlrpc.size());  // size must be 2
 
   for (int i = 0; i < box_xmlrpc.size(); ++i)
   {
@@ -130,8 +129,7 @@ Box makeBoxFromString(const std::string& box_string, const Box& last_box)
     return last_box;
   }
 
-  std::vector<geometry_msgs::Point32> points;
-  points.resize(vvf.size());  // points.size() == 2
+  std::vector<geometry_msgs::Point32> points(vvf.size());  // size must be 2
 
   for (unsigned int i = 0; i < vvf.size(); i++)
   {

--- a/src/box_utils.h
+++ b/src/box_utils.h
@@ -1,3 +1,40 @@
+/*
+ *  Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, SmileRobotics, Japan
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   1. Redistributions of source code must retain the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *   3. Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ *  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #ifndef BOX_UTILS_H
 #define BOX_UTILS_h
 

--- a/src/box_utils.h
+++ b/src/box_utils.h
@@ -1,0 +1,17 @@
+#ifndef BOX_UTILS_H
+#define BOX_UTILS_h
+
+#include <vector>
+
+#include <geometry_msgs/Point32.h>
+
+#include "box.h"
+#include "polygon_utils.h"
+
+std::string boxToString(const Box& box);
+Box makeBoxFromTwoPoints(const std::vector<geometry_msgs::Point32>& points);
+Box makeBoxFromXMLRPC(const XmlRpc::XmlRpcValue& box_xmlrpc, const std::string& full_param_name);
+Box makeBoxFromString(const std::string& box_string, const Box& last_box);
+Box padBox(const Box& polygon, double padding);
+
+#endif

--- a/src/box_utils.h
+++ b/src/box_utils.h
@@ -46,7 +46,7 @@
 #include "polygon_utils.h"
 
 std::string boxToString(const Box& box);
-Box makeBoxFromTwoPoints(const std::vector<geometry_msgs::Point32>& points);
+Box makeBoxFromTwoPoints(const geometry_msgs::Point32& point0, const geometry_msgs::Point32& point1);
 Box makeBoxFromXMLRPC(const XmlRpc::XmlRpcValue& box_xmlrpc, const std::string& full_param_name);
 Box makeBoxFromString(const std::string& box_string, const Box& last_box);
 Box padBox(const Box& polygon, double padding);


### PR DESCRIPTION
This PR adds the following utility functions for `Box` struct:
- std::string boxToString(const Box& box)
- Box makeBoxFromTwoPoints(const std::vector<geometry_msgs::Point32>& points)
- Box makeBoxFromXMLRPC(const XmlRpc::XmlRpcValue& box_xmlrpc, const std::string& full_param_name)
- Box makeBoxFromString(const std::string& box_string, const Box& last_box)
- Box padBox(const Box& polygon, double padding)
