### PR TITLE
[box_utils] Fix argument name

### DIFF
--- a/src/box_utils.h
+++ b/src/box_utils.h
@@ -49,6 +49,6 @@ std::string boxToString(const Box& box);
 Box makeBoxFromTwoPoints(const geometry_msgs::Point32& point0, const geometry_msgs::Point32& point1);
 Box makeBoxFromXMLRPC(const XmlRpc::XmlRpcValue& box_xmlrpc, const std::string& full_param_name);
 Box makeBoxFromString(const std::string& box_string, const Box& last_box);
-Box padBox(const Box& polygon, double padding);
+Box padBox(const Box& box, double padding);
 
 #endif


### PR DESCRIPTION
I note that the definition is correct:
https://github.com/smilerobotics/laser_filters/blob/7b8ed291678cf3cb22e36b8007ab81bb9c7563c2/src/box_utils.cpp#L152