### PR TITLE
Add MultiBoxFilter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(laser_scan_filters
   src/array_filter.cpp
   src/box_filter.cpp
   src/box_utils.cpp
+  src/multi_box_filter.cpp
   src/polygon_filter.cpp
   src/polygon_utils.cpp
   src/speckle_filter.cpp

--- a/examples/multi_box_filter.yaml
+++ b/examples/multi_box_filter.yaml
@@ -1,0 +1,7 @@
+scan_filter_chain:
+- name: box_filter
+  type: laser_filters/LaserScanMultiBoxFilter
+  params:
+    box_frame: base_link
+    box: [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]
+    invert: false

--- a/examples/multi_box_filter_example.launch
+++ b/examples/multi_box_filter_example.launch
@@ -1,0 +1,6 @@
+<launch>
+  <node pkg="laser_filters" type="scan_to_scan_filter_chain" output="screen" name="laser_filter">
+    <remap from="scan" to="base_scan" />
+    <rosparam command="load" file="$(find laser_filters)/examples/multi_box_filter.yaml" />
+  </node>
+</launch>

--- a/include/laser_filters/multi_box_filter.h
+++ b/include/laser_filters/multi_box_filter.h
@@ -1,0 +1,96 @@
+/*
+ *  Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, SmileRobotics, Japan
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   1. Redistributions of source code must retain the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *   3. Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ *  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MULTI_BOX_FILTER_H
+#define MULTI_BOX_FILTER_H
+
+#include <dynamic_reconfigure/server.h>
+#include <filters/filter_base.h>
+#include <laser_geometry/laser_geometry.h>
+#include <sensor_msgs/LaserScan.h>
+#include <sensor_msgs/point_cloud_conversion.h>
+#include <tf/transform_datatypes.h>
+#include <tf/transform_listener.h>
+
+#include "box.h"
+#include "box_utils.h"
+#include "laser_filters/BoxFilterConfig.h"
+
+namespace laser_filters
+{
+/**
+ * @brief This is a filter that removes points in a laser scan inside of a cartesian box.
+ */
+class LaserScanMultiBoxFilter : public filters::FilterBase<sensor_msgs::LaserScan>
+{
+public:
+  LaserScanMultiBoxFilter();
+  bool configure();
+
+  bool update(const sensor_msgs::LaserScan& input_scan, sensor_msgs::LaserScan& filtered_scan);
+
+private:
+  // for dynamic configuration
+  std::shared_ptr<dynamic_reconfigure::Server<BoxFilterConfig>> dyn_server_;
+  boost::recursive_mutex own_mutex_;
+
+  // parameters
+  std::string box_frame_;
+  Box box_;
+  double box_padding_;
+  bool invert_filter_;
+  bool up_and_running_;
+  laser_geometry::LaserProjection projector_;
+
+  // tf listener to transform scans into the box_frame
+  tf::TransformListener tf_;
+
+  // defines two opposite corners of the box
+  tf::Point min_, max_;
+
+  // checks if points in box
+  bool inBox(const tf::Point& point);
+
+  // sets `max_` and `min_` from the argument
+  void updateTfPoints(const Box& box);
+
+  // dynamic_reconfigure callback
+  void reconfigureCB(laser_filters::BoxFilterConfig& config, uint32_t level);
+};
+}  // namespace laser_filters
+
+#endif  // MULTI_BOX_FILTER_H

--- a/laser_filters_plugins.xml
+++ b/laser_filters_plugins.xml
@@ -1,94 +1,83 @@
 <class_libraries>
   <library path="lib/liblaser_scan_filters">
-    <class name="laser_filters/LaserArrayFilter" type="laser_filters::LaserArrayFilter" 
-	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+    <class name="laser_filters/LaserArrayFilter" type="laser_filters::LaserArrayFilter" base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
 	This is a filter which runs two internal MultiChannelFilterChain filters on the range and intensity measurements.  
       </description>
     </class>
-    <class name="laser_filters/LaserScanIntensityFilter" type="laser_filters::LaserScanIntensityFilter" 
-	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+    <class name="laser_filters/LaserScanIntensityFilter" type="laser_filters::LaserScanIntensityFilter" base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
 	This is a filter which filters sensor_msgs::LaserScan messages based on intensity
       </description>
     </class>
-    <class name="laser_filters/LaserScanRangeFilter" type="laser_filters::LaserScanRangeFilter" 
-	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+    <class name="laser_filters/LaserScanRangeFilter" type="laser_filters::LaserScanRangeFilter" base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
 	This is a filter which filters sensor_msgs::LaserScan messages based on range
       </description>
     </class>
-    <class name="laser_filters/ScanShadowsFilter" type="laser_filters::ScanShadowsFilter" 
-	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+    <class name="laser_filters/ScanShadowsFilter" type="laser_filters::ScanShadowsFilter" base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
 	This is a filter which filters points from a laser scan that look like the veiling effect.
       </description>
     </class>
-    <class name="laser_filters/InterpolationFilter" type="laser_filters::InterpolationFilter" 
-	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+    <class name="laser_filters/InterpolationFilter" type="laser_filters::InterpolationFilter" base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
       This is a filter that will generate range readings for error readings in a scan by interpolating between valid readings on either side of the error
       </description>
     </class>
-    <class name="laser_filters/LaserScanAngularBoundsFilter" type="laser_filters::LaserScanAngularBoundsFilter" 
-	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+    <class name="laser_filters/LaserScanAngularBoundsFilter" type="laser_filters::LaserScanAngularBoundsFilter" base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
 	 This is a filter that removes points in a laser scan outside of certain angular bounds.
       </description>
     </class>
-    <class name="laser_filters/LaserScanAngularBoundsFilterInPlace" type="laser_filters::LaserScanAngularBoundsFilterInPlace" 
-	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+    <class name="laser_filters/LaserScanAngularBoundsFilterInPlace" type="laser_filters::LaserScanAngularBoundsFilterInPlace" base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
 	 This is a filter that removes points in a laser scan inside of certain angular bounds.
       </description>
     </class>
-     <class name="laser_filters/LaserScanBoxFilter" type="laser_filters::LaserScanBoxFilter" 
-	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+    <class name="laser_filters/LaserScanBoxFilter" type="laser_filters::LaserScanBoxFilter" base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
 	 This is a filter that removes points in a laser scan inside of a cartesian box.
       </description>
     </class>
-      <class name="laser_filters/LaserScanPolygonFilter" type="laser_filters::LaserScanPolygonFilter"
-	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+    <class name="laser_filters/LaserScanMultiBoxFilter" type="laser_filters::LaserScanMultiBoxFilter" base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+      <description>
+ This is a filter that removes points in a laser scan inside of cartesian boxes.
+    </description>
+    </class>
+    <class name="laser_filters/LaserScanPolygonFilter" type="laser_filters::LaserScanPolygonFilter" base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
 	This is a filter that removes points in a laser scan inside of a polygon.
       </description>
     </class>
-    <class name="laser_filters/LaserScanSpeckleFilter" type="laser_filters::LaserScanSpeckleFilter"
-	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+    <class name="laser_filters/LaserScanSpeckleFilter" type="laser_filters::LaserScanSpeckleFilter" base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
  	This is a filter that removes speckle points in a laser scan by looking at neighbor points.
       </description>
     </class>
-    <class name="laser_filters/LaserScanMaskFilter" type="laser_filters::LaserScanMaskFilter" 
-	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+    <class name="laser_filters/LaserScanMaskFilter" type="laser_filters::LaserScanMaskFilter" base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
 	 This is a filter that removes points on directions defined in a mask from a laser scan.
       </description>
     </class>
-    <class name="laser_filters/LaserMedianFilter" type="laser_filters::LaserMedianFilter" 
-	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+    <class name="laser_filters/LaserMedianFilter" type="laser_filters::LaserMedianFilter" base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
 	DEPRECATED: This is a median filter which filters sensor_msgs::LaserScan messages.  
       </description>
     </class>
-    <class name="laser_filters/LaserScanFootprintFilter" type="laser_filters::LaserScanFootprintFilter" 
-	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+    <class name="laser_filters/LaserScanFootprintFilter" type="laser_filters::LaserScanFootprintFilter" base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
 	DEPRECATED: This is a filter which filters points out of a laser scan which are inside the inscribed radius.
       </description>
     </class>
-    <class name="laser_filters/ScanBlobFilter"
-           type="laser_filters::ScanBlobFilter"
-               base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+    <class name="laser_filters/ScanBlobFilter" type="laser_filters::ScanBlobFilter" base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
         This is a filter which extract blob object (human's foot, chair's foot) from a laser.
       </description>
     </class>
   </library>
   <library path="lib/libpointcloud_filters">
-    <class name="laser_filters/PointCloudFootprintFilter" type="laser_filters::PointCloudFootprintFilter" 
-	    base_class_type="filters::FilterBase<sensor_msgs::PointCloud>">
+    <class name="laser_filters/PointCloudFootprintFilter" type="laser_filters::PointCloudFootprintFilter" base_class_type="filters::FilterBase<sensor_msgs::PointCloud>">
       <description>
 	DEPRECATED: Remove points from the pointcloud inside the robot base. 
       </description>

--- a/src/laser_scan_filters.cpp
+++ b/src/laser_scan_filters.cpp
@@ -38,6 +38,7 @@
 #include "laser_filters/angular_bounds_filter.h"
 #include "laser_filters/angular_bounds_filter_in_place.h"
 #include "laser_filters/box_filter.h"
+#include "laser_filters/multi_box_filter.h"
 #include "laser_filters/polygon_filter.h"
 #include "laser_filters/speckle_filter.h"
 #include "laser_filters/scan_blob_filter.h"
@@ -57,6 +58,7 @@ PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanFootprintFilter, filters::FilterB
 PLUGINLIB_EXPORT_CLASS(laser_filters::ScanShadowsFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::InterpolationFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanBoxFilter, filters::FilterBase<sensor_msgs::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanMultiBoxFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanPolygonFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanSpeckleFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanMaskFilter, filters::FilterBase<sensor_msgs::LaserScan>)

--- a/src/multi_box_filter.cpp
+++ b/src/multi_box_filter.cpp
@@ -1,0 +1,218 @@
+/*
+ *  Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, SmileRobotics, Japan
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   1. Redistributions of source code must retain the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *   3. Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ *  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <algorithm>
+
+#include <dynamic_reconfigure/server.h>
+#include <ros/ros.h>
+
+#include "box.h"
+#include "box_utils.h"
+#include "laser_filters/BoxFilterConfig.h"
+#include "laser_filters/multi_box_filter.h"
+
+namespace laser_filters
+{
+LaserScanMultiBoxFilter::LaserScanMultiBoxFilter()
+{
+}
+
+bool LaserScanMultiBoxFilter::configure()
+{
+  up_and_running_ = true;
+  XmlRpc::XmlRpcValue box_xmlrpc;
+
+  ros::NodeHandle private_nh("~" + getName());
+  dyn_server_.reset(new dynamic_reconfigure::Server<BoxFilterConfig>(own_mutex_, private_nh));
+
+  bool box_set = getParam("box", box_xmlrpc);
+  bool box_frame_set = getParam("box_frame", box_frame_);
+  bool invert_set = getParam("invert", invert_filter_);
+
+  if (!box_set)
+  {
+    ROS_ERROR("box is not set!");
+    return false;
+  }
+  if (!box_frame_set)
+  {
+    ROS_ERROR("box_frame is not set!");
+    return false;
+  }
+  if (!invert_set)
+  {
+    ROS_WARN("invert_filter is not set, assuming false");
+    invert_filter_ = false;
+  }
+
+  box_ = makeBoxFromXMLRPC(box_xmlrpc, "box");
+
+  double box_padding = 0;
+  getParam("box_padding", box_padding);
+
+  BoxFilterConfig param_config;
+  param_config.box = boxToString(box_);
+  param_config.box_padding = box_padding;
+  param_config.invert = invert_filter_;
+  dyn_server_->updateConfig(param_config);
+
+  box_ = padBox(box_, box_padding);
+  updateTfPoints(box_);
+
+  // sets dynamic_reconfigure callback
+  dynamic_reconfigure::Server<BoxFilterConfig>::CallbackType f =
+      boost::bind(&LaserScanMultiBoxFilter::reconfigureCB, this, _1, _2);
+  dyn_server_->setCallback(f);
+
+  ROS_INFO("Multi Box Filter started");
+  return true;
+}
+
+bool LaserScanMultiBoxFilter::update(const sensor_msgs::LaserScan& input_scan, sensor_msgs::LaserScan& output_scan)
+{
+  output_scan = input_scan;
+  sensor_msgs::PointCloud2 laser_cloud;
+
+  std::string error_msg;
+
+  bool success = tf_.waitForTransform(box_frame_, input_scan.header.frame_id,
+                                      input_scan.header.stamp +
+                                          ros::Duration().fromSec(input_scan.ranges.size() * input_scan.time_increment),
+                                      ros::Duration(1.0), ros::Duration(0.01), &error_msg);
+  if (!success)
+  {
+    ROS_WARN("Could not get transform, ignoring laser scan! %s", error_msg.c_str());
+    return false;
+  }
+
+  try
+  {
+    projector_.transformLaserScanToPointCloud(box_frame_, input_scan, laser_cloud, tf_);
+  }
+  catch (tf::TransformException& ex)
+  {
+    if (up_and_running_)
+    {
+      ROS_WARN_THROTTLE(1, "Dropping Scan: Tansform unavailable %s", ex.what());
+      return true;
+    }
+    else
+    {
+      ROS_INFO_THROTTLE(.3, "Ignoring Scan: Waiting for TF");
+    }
+    return false;
+  }
+  const int i_idx_c = sensor_msgs::getPointCloud2FieldIndex(laser_cloud, "index");
+  const int x_idx_c = sensor_msgs::getPointCloud2FieldIndex(laser_cloud, "x");
+  const int y_idx_c = sensor_msgs::getPointCloud2FieldIndex(laser_cloud, "y");
+  const int z_idx_c = sensor_msgs::getPointCloud2FieldIndex(laser_cloud, "z");
+
+  if (i_idx_c == -1 || x_idx_c == -1 || y_idx_c == -1 || z_idx_c == -1)
+  {
+    ROS_INFO_THROTTLE(.3, "x, y, z and index fields are required, skipping scan");
+  }
+
+  const int i_idx_offset = laser_cloud.fields[i_idx_c].offset;
+  const int x_idx_offset = laser_cloud.fields[x_idx_c].offset;
+  const int y_idx_offset = laser_cloud.fields[y_idx_c].offset;
+  const int z_idx_offset = laser_cloud.fields[z_idx_c].offset;
+
+  const int pstep = laser_cloud.point_step;
+  const long int pcount = laser_cloud.width * laser_cloud.height;
+  const long int limit = pstep * pcount;
+
+  int i_idx, x_idx, y_idx, z_idx;
+  for (i_idx = i_idx_offset, x_idx = x_idx_offset, y_idx = y_idx_offset, z_idx = z_idx_offset; x_idx < limit;
+       i_idx += pstep, x_idx += pstep, y_idx += pstep, z_idx += pstep)
+  {
+    // TODO works only for float data types and with an index field
+    // I'm working on it, see https://github.com/ros/common_msgs/pull/78
+    float x = *((float*)(&laser_cloud.data[x_idx]));
+    float y = *((float*)(&laser_cloud.data[y_idx]));
+    float z = *((float*)(&laser_cloud.data[z_idx]));
+    int index = *((int*)(&laser_cloud.data[i_idx]));
+
+    tf::Point point(x, y, z);
+
+    if (!invert_filter_)
+    {
+      if (inBox(point))
+      {
+        output_scan.ranges[index] = std::numeric_limits<float>::quiet_NaN();
+      }
+    }
+    else
+    {
+      if (!inBox(point))
+      {
+        output_scan.ranges[index] = std::numeric_limits<float>::quiet_NaN();
+      }
+    }
+  }
+  up_and_running_ = true;
+  return true;
+}
+
+bool LaserScanMultiBoxFilter::inBox(const tf::Point& point)
+{
+  return point.x() < max_.x() && point.x() > min_.x() && point.y() < max_.y() && point.y() > min_.y() &&
+         point.z() < max_.z() && point.z() > min_.z();
+}
+
+void LaserScanMultiBoxFilter::updateTfPoints(const Box& box)
+{
+  max_.setX(box.max.x);
+  max_.setY(box.max.y);
+  max_.setZ(box.max.z);
+
+  min_.setX(box.min.x);
+  min_.setY(box.min.y);
+  min_.setZ(box.min.z);
+
+  return;
+}
+
+void LaserScanMultiBoxFilter::reconfigureCB(laser_filters::BoxFilterConfig& config, uint32_t level)
+{
+  invert_filter_ = config.invert;
+  Box box_new = makeBoxFromString(config.box, box_);
+  box_ = padBox(box_new, config.box_padding);
+  updateTfPoints(box_);
+
+  return;
+}
+}  // namespace laser_filters


### PR DESCRIPTION
towards #1; instead of #10 . 

In this PR, LaserScanMultiBoxFilter still only supports one box (WIP).

## How to Verify the Functions

1. Replace `test/fake_laser.py` by the following code:
```python
#!/usr/bin/python

PKG = 'laser_filters' # this package name
import roslib; roslib.load_manifest(PKG)

import rospy
from sensor_msgs.msg import LaserScan

def laser_test():
    pub = rospy.Publisher('base_scan', LaserScan)
    rospy.init_node('laser_test')
    laser_msg = LaserScan()

    laser_msg.header.frame_id = 'base_link'
    laser_msg.angle_min = -1.5
    laser_msg.angle_max = 1.5
    laser_msg.angle_increment = 0.1
    laser_msg.time_increment = 0.1
    laser_msg.scan_time = 0.1
    laser_msg.range_min = 0.5
    laser_msg.range_max = 1.5    
    laser_msg.ranges = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 9.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 5.0, 1.0]
    laser_msg.intensities = laser_msg.ranges 

    r = rospy.Rate(10) # 10hz
    while not rospy.is_shutdown():
        laser_msg.header.stamp = rospy.get_rostime()
        pub.publish(laser_msg)
        r.sleep()


if __name__ == '__main__':
  try:
        laser_test()
  except rospy.ROSInterruptException: pass
```

2. Launch `box_filter`
```bash
roslaunch laser_filters multi_box_filter_example.launch
```

3. Run `fake_laser` node
```bash
rosrun ler_filters fake_laser.py
```

4. View data on RViz and change the box parameters in rqt (see the figure)

![Screenshot from 2021-04-21 12-46-16](https://user-images.githubusercontent.com/15957608/115494647-08712800-a2a1-11eb-9b75-ac2e28d26155.png)
