### PR TITLE
[multi_box_filter] Use mutex lock while filtering

### DIFF
--- a/include/laser_filters/multi_box_filter.h
+++ b/include/laser_filters/multi_box_filter.h
@@ -50,6 +50,7 @@
 #include <sensor_msgs/point_cloud_conversion.h>
 #include <tf/transform_datatypes.h>
 #include <tf/transform_listener.h>
+#include <boost/thread/recursive_mutex.hpp>
 
 #include "box.h"
 #include "box_utils.h"

--- a/src/multi_box_filter.cpp
+++ b/src/multi_box_filter.cpp
@@ -41,6 +41,7 @@
 #include <geometry_msgs/PolygonStamped.h>
 #include <jsk_recognition_msgs/PolygonArray.h>
 #include <ros/ros.h>
+#include <boost/interprocess/sync/scoped_lock.hpp>
 
 #include "box.h"
 #include "box_utils.h"
@@ -109,6 +110,9 @@ bool LaserScanMultiBoxFilter::configure()
 
 bool LaserScanMultiBoxFilter::update(const sensor_msgs::LaserScan& input_scan, sensor_msgs::LaserScan& output_scan)
 {
+  // prevents the box array from updating in this function
+  boost::recursive_mutex::scoped_lock lock(own_mutex_);
+
   // publishes the box array
   ros::Time now = ros::Time::now();
   jsk_recognition_msgs::PolygonArray box_array_msg;


### PR DESCRIPTION
I missed to implement this, while other filters with dynamic_reconfigure use. Without locking, there exists a risk that makes filtering processes Inconsistent: box shapes can be changed in the same filtering process (loop).

E.g. polygon_filter:
https://github.com/smilerobotics/laser_filters/blob/9a74bfc89d699e1ef8affa3ba889ab585528a12b/src/polygon_filter.cpp#L108